### PR TITLE
Support for Plymouth bootsplash, multilanguage support and debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,147 @@
 # fido2luks
 
-This is an initramfs-tools extension to unlock LUKS-encrypted
-volumes at boot time using a FIDO2 token (YubiKey, Nitrokey, ...).
+This is an initramfs-tools extension to unlock LUKS-encrypted volumes at boot time using a FIDO2 token (YubiKey, Nitrokey, ...).
 
-`fido2luks` is designed for scenarios where a FIDO2 token has been
-enrolled into a LUKS volume using `systemd-cryptenroll --fido2-device`,
-but systemd itself is not used in the initramfs.
+`fido2luks` is designed for scenarios where a FIDO2 token has been enrolled into a LUKS volume using `systemd-cryptenroll --fido2-device`, but systemd itself is not used in the initramfs.
 
-This has been successfully tested with Debian bookworm and trixie.
+Updated script has support for Plymouth bootsplash, has multilingual support (curently English and SLovenian language) and can supress technical/debug messages and shown only user-friendly output.
+
+Script was tested with Yubikey 5 NFC and Nitrokey 3A Mini on Debian 13.4, however it should support any FIDO2 key.
+
+To disable technical/debug messages (and show only messages suitable for non-tecnical users) change:
+
+`FIDO2LUKS_DEBUG=${FIDO2LUKS_DEBUG:-1}`
+
+to:
+
+`FIDO2LUKS_DEBUG=${FIDO2LUKS_DEBUG:-0}`
+
+Default language is English, you can change it to Slovenian with:
+
+`FIDO2LUKS_LANG=${FIDO2LUKS_LANG:-sl}`
 
 ## Installation
 
-Here's how to install `fido2luks` if it's not already available on
-your distro:
+Here's how to install `fido2luks` if it's not already available on your distro:
 
-- Dependencies: you need `initramfs-tools`, `fido2-tools` and `jq` on
-  your system.
+- Dependencies: you need `initramfs-tools`, `fido2-tools` and `jq` on your system. On Debian you can install them with: `apt install fido2-tools jq -y`.
 
 - Install `fido2luks` using one of these options:
-  - Download a `.deb` package from the GitHub
-    [releases](https://github.com/bertogg/fido2luks/releases) page.
-  - Build your own package using the provided scripts by running
-    `fakeroot debian/rules binary`.
-  - Simply run `make install` (this won't generate or install any
-    `.deb` package).
+  1. Download a `.deb` package from the GitHub [releases](https://github.com/bertogg/fido2luks/releases) page and install it:
+     ```
+     wget https://github.com/bertogg/fido2luks/releases/download/v0.0.3/fido2luks_0.0.3-1_all.deb
+     apt install ./fido2luks_0.0.3-1_all.deb
+     ```
+  2. Build your own package using the provided scripts by running `fakeroot debian/rules binary`.
+  3. Simply run `make install` (this won't generate or install any `.deb` package).
+
+Copy my patched `keyscript.sh` to `/lib/fido2luks/keyscript.sh`.
 
 ## How to use it
 
-- ⚠️ **Warning**: this can render your system unbootable, so make sure
-  that you have a backup of your files or a working initramfs that you
+⚠️ **Warning**: this can render your system unbootable, so make sure that you have a backup of your files or a working initramfs that you
   can use as a fallback in case things go wrong.
 
-- Enroll your FIDO2 token into the LUKS volume, for example:
-  - `systemd-cryptenroll --fido2-device=auto --fido2-with-client-pin=true --fido2-with-user-presence=true /dev/XXX`
-  - After that, if you run `cryptsetup luksDump /dev/XXX` you should be
-    able to see the `systemd-fido2` token data.
+1. Install FIDO2 tools:
+   ```
+   apt install libfido2-dev libfido2-1 fido2-tools -y
+   ```
+   
+2. Enroll your FIDO2 token into the LUKS volume, for example, if you have `/dev/nvme0n1p5` (so called "Encrypted LVM" on Debian):
+  1. `systemd-cryptenroll --fido2-device=auto --fido2-with-client-pin=true --fido2-with-user-presence=true /dev/nvme0n1p5`
+  2. After that, if you run `cryptsetup luksDump /dev/nvme0n1p5` you should be able to see the `systemd-fido2` token data.
 
-- Edit `/etc/crypttab` and add `keyscript=/usr/lib/fido2luks/keyscript.sh`
-  to the options of the volume that you want to unlock.
+3. Edit `/etc/crypttab` and add `keyscript=/usr/lib/fido2luks/keyscript.sh` to the options of the volume that you want to unlock (for instance `nvme0n1p5_crypt`):
+   ```
+   sed -i \
+   '/^nvme0n1p5_crypt /{
+     /keyscript=/! s#$#,keyscript=/lib/fido2luks/keyscript.sh#
+     s#keyscript=[^, ]*#keyscript=/lib/fido2luks/keyscript.sh#
+   }' \
+   /etc/crypttab
+   ```
 
-- Generate a new initramfs with `update-initramfs -u`.
+4. Generate a new initramfs with `update-initramfs -u`.
 
-That's it. Next time you boot the system `fido2luks` should detect if
-your FIDO2 token is inserted and use it to unlock the LUKS volume. If
-the token is not detected then it will fall back to using a regular
-passphrase as usual.
+That's it. Next time you boot the system `fido2luks` should detect if your FIDO2 token is inserted and use it to unlock the LUKS volume. If the token is not detected then it will fall back to using a regular passphrase as usual.
 
-If you have multiple tokens you can enroll all of them, and
-`fido2luks` will detect which one to use at boot time.
+If you have multiple tokens you can enroll all of them, and `fido2luks` will detect which one to use at boot time.
 
-If the token is connected but not detected during boot make sure that
-the initramfs contains the necessary drivers. Check your
-`initramfs.conf` and set `MODULES=most` or add the necessary modules
-manually.
+If the token is connected but not detected during boot make sure that the initramfs contains the necessary drivers. Check your `initramfs.conf` and set `MODULES=most` or add the necessary modules manually.
 
-## How this works
+## Some useful commands
 
-If you are not interested in the technical details you can skip this
-section.
+List FIDO tokens:
+```
+fido2-token -L
+```
 
-When systemd enrolls a FIDO2 token into a LUKS volume it uses an
-extension called hmac-secret, supported by many hardware tokens.
+Get FIDO2 properties:
+```
+fido2-token -I /dev/hidraw1
+```
 
-In a nutshell, the token calculates an HMAC using a secret that never
-leaves the device and a salt provided by the user. The result is sent
-back to the user and is used to unlock the LUKS volume.
+Sets an initial FIDO2 PIN:
+```
+fido2-token -S /dev/hidraw1
+```
 
-Since nothing is stored on the hardware token itself the user needs to
-provide some data that is kept on the LUKS header:
+Change the existing FIDO2 PIN:
+```
+fido2-token -C /dev/hidraw1
+```
 
+Check if FIDO2 PIN is set:
+```
+fido2-token -I /dev/hidraw1 | grep 'clientPin\|pin retries'
+```
+
+Sample output:
+```
+options: rk, up, noplat, credMgmt, clientPin, nolargeBlobs, pinUvAuthToken, makeCredUvNotRqd
+pin retries: 8
+```
+
+- `clientPin`: FIDO2 PIN is configured
+- `pin retries`: number of remaining PIN retries
+
+## Important information about security
+
+Using a FIDO2 security key with LUKS disk encryption significantly improves security. To unlock the disk, multiple factors are required:
+- Something you have (the FIDO2 security key)
+- Something you know (the PIN for your FIDO2 security key)
+- User presence, confirmed by physically touching the key
+
+Importantly, the PIN is verified inside the FIDO2 device itself, not by LUKS. The LUKS system never sees or stores the PIN.
+
+However, security key can be lost, damaged, or unavailable. Also, there is a chance that kernel or initramfs updates may temporarily break FIDO2 support and in that case you will not be able to unlock the disk with FIDO2 security key. And finally, entering the wrong PIN too many times can lock the USB key.
+
+And if the PIN becomes blocked and must be reset, the FIDO2 credentials stored on the device are typically erased. This means the associated LUKS key will no longer work.
+
+For these reasons, it is strongly recommended to always keep a backup LUKS passphrase and, ideally, multiple FIDO2 keys (this script already supports multiple security USB keys and (multiple) LUKS passwords).
+
+Best practice for high assurance would be:
+- use 2–3 FIDO2 keys (different vendors if possible)
+- strong LUKS passphrase stored securely (for instance printed and sealed somewhere)
+
+## How this scipt works
+
+If you are not interested in the technical details you can skip this section.
+
+When systemd enrolls a FIDO2 token into a LUKS volume it uses an extension called hmac-secret, supported by many hardware tokens.
+
+In a nutshell, the token calculates an HMAC using a secret that never leaves the device and a salt provided by the user. The result is sent back to the user and is used to unlock the LUKS volume.
+
+Since nothing is stored on the hardware token itself the user needs to provide some data that is kept on the LUKS header:
 - A credential ID (previously generated during the enrollment process).
 - A _relying party_ ID (`io.systemd.cryptsetup` in this case).
-- The aforementioned salt (which should be random and different for
-  each LUKS volume).
-- Some settings such as whether to require a PIN or presence
-  verification (usually physically touching the USB key).
+- The aforementioned salt (which should be random and different for each LUKS volume).
+- Some settings such as whether to require a PIN or presence verification (usually physically touching the USB key).
 
-Check out the scripts in the examples/ directory to see how to
-generate your own credentials and secrets. See also the
-`fido2-cred(1)` and `fido2-assert(1)` manpages for more details.
+Check out the scripts in the examples/ directory to see how to generate your own credentials and secrets. See also the `fido2-cred(1)` and `fido2-assert(1)` manpages for more details.
 
 ## Credits and license
 
-fido2luks was written by Alberto Garcia.
+fido2luks was written by Alberto Garcia. Plymouth bootslpash patch and multilingual support was writen by Matej Kovačič. 
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or (at
-your option) any later version.
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is an initramfs-tools extension to unlock LUKS-encrypted volumes at boot ti
 
 Updated script has support for Plymouth bootsplash, has multilingual support (curently English and SLovenian language) and can supress technical/debug messages and shown only user-friendly output.
 
+<img width="556" height="353" alt="image" src="https://github.com/user-attachments/assets/b855777d-b227-4e5e-9243-1d59697faba0" />
+
 Script was tested with Yubikey 5 NFC and Nitrokey 3A Mini on Debian 13.4, however it should support any FIDO2 key.
 
 To disable technical/debug messages (and show only messages suitable for non-tecnical users) change:

--- a/keyscript.sh
+++ b/keyscript.sh
@@ -10,22 +10,20 @@ LUKS_TOKEN_LIST=$(mktemp -t tokenlist.XXXXXX)
 LUKS_TOKEN=$(mktemp -t token.XXXXXX)
 trap cleanup INT EXIT
 
-# Enable or disable technical/debug messages shown via Plymouth (and in text mode).
-# Default is 0 so normal users see only human-readable recovery messages.
+# Enable technical/debug messages shown via Plymouth and text console.
+# Set to 1 while testing. After everything works reliably, you can set this back to 0.
 FIDO2LUKS_DEBUG=${FIDO2LUKS_DEBUG:-1}
 
 # Language for user-facing messages: en, sl.
-# Default is English unless explicitly changed in this script or environment.
 FIDO2LUKS_LANG=${FIDO2LUKS_LANG:-en}
 
-# Return success only when the Plymouth client exists and
-# the Plymouth daemon is currently running in the initramfs.
+# How long to wait for the FIDO2 USB key to appear during initramfs boot.
+FIDO2LUKS_WAIT_SECONDS=${FIDO2LUKS_WAIT_SECONDS:-20}
+
 plymouth_available () {
     command -v plymouth >/dev/null 2>&1 && plymouth --ping >/dev/null 2>&1
 }
 
-# Translate user-facing messages. Keep technical/debug strings outside this
-# function so they remain useful for troubleshooting and upstream reports.
 msg_text () {
     _msg_id=$1
     _arg1=${2:-}
@@ -67,8 +65,8 @@ Dotaknite se varnostnega USB ključa ZDAJ.
 
 Prehod na obnovitveno šifrirno geslo čez ${_arg1}s.
 EOF
-
             ;;
+
         *:touch_countdown)
             cat <<EOF
 Please confirm your presence.
@@ -136,8 +134,6 @@ EOF
     esac
 }
 
-# Print a status message to the text console as before, and
-# also mirror it to Plymouth when Plymouth is available.
 plymouth_message () {
     echo "*** $*" >&2
     if plymouth_available; then
@@ -145,17 +141,12 @@ plymouth_message () {
     fi
 }
 
-# Print technical/debug messages only when FIDO2LUKS_DEBUG=1.
-# Human-readable recovery messages should use plymouth_message directly.
 debug_message () {
     if [ "$FIDO2LUKS_DEBUG" = "1" ]; then
-        plymouth_message "$@"
+        plymouth_message "DEBUG: $*"
     fi
 }
 
-# Show an explicit hint for the required physical touch step.
-# This is especially useful with graphical Plymouth themes,
-# because the FIDO2 authenticator itself gives no text prompt.
 plymouth_touch_hint () {
     if [ "$REQ_UP" = "true" ]; then
         plymouth_message "$(msg_text touch_hint)"
@@ -163,27 +154,53 @@ plymouth_touch_hint () {
 }
 
 try_fido2_unlock () {
-    # Get all tokens from the LUKS header with FIDO2 credentials.
-    # Sort the array, placing entries with "fido2-uv-required: true" at the end.
+    debug_message "Starting FIDO2 LUKS unlock"
+    debug_message "CRYPTTAB_SOURCE=$CRYPTTAB_SOURCE"
+    debug_message "PATH=$PATH"
+    debug_message "cryptsetup path=$(command -v cryptsetup || echo missing)"
+    debug_message "jq path=$(command -v jq || echo missing)"
+    debug_message "fido2-token path=$(command -v fido2-token || echo missing)"
+    debug_message "fido2-assert path=$(command -v fido2-assert || echo missing)"
+
+    if [ -z "$CRYPTTAB_SOURCE" ]; then
+        debug_message "CRYPTTAB_SOURCE is empty"
+        return 1
+    fi
+
+    # Read FIDO2 tokens from the LUKS2 header.
+    # Important: ignore orphaned tokens with empty keyslots.
     if ! cryptsetup luksDump --dump-json-metadata "$CRYPTTAB_SOURCE" | \
-            jq -e '[.tokens[] | select(."fido2-credential" != null)] | sort_by(."fido2-uv-required")' > "$LUKS_TOKEN_LIST"; then
-        debug_message "Error reading LUKS header in $CRYPTTAB_SOURCE"
+            jq -e '[.tokens[]
+                    | select(."fido2-credential" != null)
+                    | select((.keyslots // []) | length > 0)]
+                   | sort_by(."fido2-uv-required")' > "$LUKS_TOKEN_LIST"; then
+        debug_message "Error reading usable FIDO2 tokens from LUKS header: $CRYPTTAB_SOURCE"
         return 1
     fi
 
-    # Count how many tokens we have.
     NTOKENS=$(jq length "$LUKS_TOKEN_LIST")
+    debug_message "Found $NTOKENS usable FIDO2 LUKS token(s)"
+
     if [ -z "$NTOKENS" ] || [ "$NTOKENS" = "0" ]; then
-        debug_message "No FIDO2 credentials found in $CRYPTTAB_SOURCE"
+        debug_message "No usable FIDO2 credentials found in $CRYPTTAB_SOURCE"
         return 1
     fi
 
-    # Check if the FIDO2 authenticator is inserted
+    # Wait for FIDO2 authenticator.
     plymouth_message "$(msg_text waiting_key)"
-    for _f in $(seq 5); do
-        FIDO2_AUTHENTICATOR=$(fido2-token -L)
+
+    FIDO2_AUTHENTICATOR=""
+    _i=0
+    while [ "$_i" -lt "$FIDO2LUKS_WAIT_SECONDS" ]; do
+        FIDO2_AUTHENTICATOR=$(fido2-token -L 2>/dev/null)
+        debug_message "fido2-token -L attempt $_i returned: $FIDO2_AUTHENTICATOR"
+
+        if [ -n "$FIDO2_AUTHENTICATOR" ]; then
+            break
+        fi
+
+        _i=$((_i + 1))
         sleep 1
-        [ -n "$FIDO2_AUTHENTICATOR" ] && break
     done
 
     if [ -z "$FIDO2_AUTHENTICATOR" ]; then
@@ -191,91 +208,51 @@ try_fido2_unlock () {
         return 1
     fi
 
-    debug_message "Found FIDO2 authenticator $FIDO2_AUTHENTICATOR"
     FIDO2_DEV=${FIDO2_AUTHENTICATOR%%:*}
+    debug_message "Using FIDO2 authenticator: $FIDO2_AUTHENTICATOR"
+    debug_message "Using FIDO2 device: $FIDO2_DEV"
 
-    # Look for a credential that is valid for the inserted FIDO2
-    # authenticator. For that we try to get an assertion from the
-    # device, with 'up' and 'pin' set to false, so it requires no user
-    # interaction.
-    for i in $(seq "$NTOKENS"); do
-        jq ".[$i-1]" "$LUKS_TOKEN_LIST" > "$LUKS_TOKEN"
-        jq -r '"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-               ."fido2-rp",
-               ."fido2-credential",
-               ."fido2-salt"' "$LUKS_TOKEN" > "$ASSERT_PARAMS"
-        REQ_UV=$(jq -r '."fido2-uv-required"' "$LUKS_TOKEN")
-        # If a credential has the 'uv' option set then unfortunately
-        # we cannot check if it's valid for the inserted FIDO2
-        # authenticator without requiring user interaction.
-        # So this is what we do:
-        # - The array of credentials is sorted, those that require UV
-        #   are at the end.
-        # - All credentials that don't require UV are tested first,
-        #   we can do that silently with the fido2-assert call.
-        # - Once we find a credential that requires UV we assume
-        #   that we can use it with the inserted authenticator.
-        # - Not all authenticators support 'uv' so pass '-t uv' only
-        #   when needed using the UV_OPT variable.
-        if [ "$REQ_UV" = "true" ]; then
-            UV_OPT="-t uv=true"
-            break
-        else
-            UV_OPT=""
-            if fido2-assert -G -t up=false -t pin=false -i "$ASSERT_PARAMS" \
-                            -o /dev/null "$FIDO2_DEV" 2> /dev/null; then
-                break
-            fi
-        fi
-        rm -f "$LUKS_TOKEN" "$ASSERT_PARAMS"
-    done
+    # Use the first usable token.
+    # This avoids the old silent pre-check path which could interact badly
+    # with PIN-required credentials.
+    jq ".[0]" "$LUKS_TOKEN_LIST" > "$LUKS_TOKEN"
 
-    if [ ! -f "$LUKS_TOKEN" ] || [ ! -f "$ASSERT_PARAMS" ]; then
-        debug_message "No valid credential found for this FIDO2 authenticator"
-        return 1
-    fi
+    jq -r '"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+           ."fido2-rp",
+           ."fido2-credential",
+           ."fido2-salt"' "$LUKS_TOKEN" > "$ASSERT_PARAMS"
 
-    # Now that we have a valid credential use it to compute the
-    # hmac-secret, which is what unlocks the LUKS volume.
+    REQ_UV=$(jq -r '."fido2-uv-required"' "$LUKS_TOKEN")
     REQ_PIN=$(jq -r '."fido2-clientPin-required"' "$LUKS_TOKEN")
     REQ_UP=$(jq -r '."fido2-up-required"' "$LUKS_TOKEN")
 
+    if [ "$REQ_UV" = "true" ]; then
+        UV_OPT="-t uv=true"
+    else
+        UV_OPT=""
+    fi
+
+    debug_message "Selected FIDO2 token: pin=$REQ_PIN up=$REQ_UP uv=$REQ_UV dev=$FIDO2_DEV"
+
     if [ "$REQ_PIN" = "true" ] && plymouth_available; then
-        # When Plymouth is active, collect the FIDO2 PIN through
-        # Plymouth's normal password dialog. This gives the user
-        # a proper graphical input field instead of a hidden tty
-        # prompt from fido2-assert.
         PIN=$(plymouth ask-for-password --prompt="$(msg_text pin_prompt)")
 
-        # Capture fido2-assert output and errors separately so
-        # Plymouth can show a live touch countdown and useful
-        # error messages before falling back to the passphrase.
         FIDO2_OUT=$(mktemp -t fido2out.XXXXXX)
         FIDO2_ERR=$(mktemp -t fido2err.XXXXXX)
         FIDO2_ERR_FILTERED=$(mktemp -t fido2err-filtered.XXXXXX)
         FIDO2_PIN=$(mktemp -t fido2pin.XXXXXX)
+
         chmod 600 "$FIDO2_PIN" 2>/dev/null || true
         printf "%s\n" "$PIN" > "$FIDO2_PIN"
-
-        # Clear the shell variable after writing the one-shot PIN
-        # to the initramfs tmpfs file used as fido2-assert stdin.
-        # This is not perfect memory erasure, but avoids keeping
-        # the PIN around longer than necessary in the shell.
         PIN=""
 
-        # fido2-assert uses /dev/tty for PIN entry when a tty is
-        # available. Run it in a new session and feed stdin from
-        # the PIN file. Do not use "setsid -w" because busybox
-        # setsid in initramfs may not support it.
         setsid fido2-assert \
             -G -h -t up="$REQ_UP" -t pin="$REQ_PIN" $UV_OPT \
             -i "$ASSERT_PARAMS" "$FIDO2_DEV" \
             < "$FIDO2_PIN" > "$FIDO2_OUT" 2> "$FIDO2_ERR" &
+
         FIDO2_PID=$!
 
-        # While fido2-assert waits for user presence, keep the
-        # Plymouth screen informative. If the key is not touched
-        # in time, fall back to the regular disk passphrase.
         if [ "$REQ_UP" = "true" ]; then
             for _seconds in 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1; do
                 if ! kill -0 "$FIDO2_PID" 2>/dev/null; then
@@ -287,8 +264,6 @@ try_fido2_unlock () {
         fi
 
         if kill -0 "$FIDO2_PID" 2>/dev/null; then
-            # The touch prompt timed out. Stop fido2-assert so the
-            # boot can proceed to the backup passphrase prompt.
             kill "$FIDO2_PID" 2>/dev/null || true
             wait "$FIDO2_PID" 2>/dev/null || true
             plymouth_message "$(msg_text touch_timeout)"
@@ -299,9 +274,6 @@ try_fido2_unlock () {
             SECRET=$(tail -n 1 "$FIDO2_OUT")
         fi
 
-        # fido2-assert still prints its own "Enter PIN for ..."
-        # prompt even when the PIN is supplied on stdin. Filter
-        # that duplicate prompt, but keep real errors visible.
         if [ -z "$SECRET" ] && [ -s "$FIDO2_ERR" ]; then
             grep -v "^Enter PIN for " "$FIDO2_ERR" > "$FIDO2_ERR_FILTERED" || true
             if [ -s "$FIDO2_ERR_FILTERED" ]; then
@@ -311,33 +283,27 @@ try_fido2_unlock () {
         fi
 
         rm -f "$FIDO2_OUT" "$FIDO2_ERR" "$FIDO2_ERR_FILTERED" "$FIDO2_PIN"
+
     else
         if [ "$REQ_PIN" = "true" ]; then
-            # Without Plymouth, keep the original console behavior
-            # but make the expected touch step explicit.
             plymouth_message "$(msg_text console_pin_touch)"
-            stty -echo
+            stty -echo 2>/dev/null || true
         elif [ "$REQ_UP" = "true" ]; then
-            # If no PIN is required, the user may still need to touch
-            # the authenticator. Make that visible in Plymouth.
             plymouth_touch_hint
         fi
 
-        SECRET=$(fido2-assert -G -h -t up="$REQ_UP" -t pin="$REQ_PIN" $UV_OPT \
-                              -i "$ASSERT_PARAMS" "$FIDO2_DEV" | tail -n 1)
+        SECRET=$(fido2-assert \
+                    -G -h -t up="$REQ_UP" -t pin="$REQ_PIN" $UV_OPT \
+                    -i "$ASSERT_PARAMS" "$FIDO2_DEV" | tail -n 1)
 
         if [ "$REQ_PIN" = "true" ]; then
-            stty echo
+            stty echo 2>/dev/null || true
+            echo >&2
         fi
     fi
 
     if [ -z "$SECRET" ]; then
-        # Show one combined recovery message so Plymouth themes
-        # do not immediately overwrite earlier lines.
         plymouth_message "$(msg_text fido_failed)"
-
-        # Give the user time to read the recovery instruction
-        # before falling back to the regular passphrase prompt.
         sleep 5
         return 1
     fi
@@ -347,7 +313,6 @@ try_fido2_unlock () {
     return 0
 }
 
-# Main execution
 if try_fido2_unlock; then
     exit 0
 fi

--- a/keyscript.sh
+++ b/keyscript.sh
@@ -14,7 +14,7 @@ trap cleanup INT EXIT
 # Default is 0 so normal users see only human-readable recovery messages.
 FIDO2LUKS_DEBUG=${FIDO2LUKS_DEBUG:-1}
 
-# Language for user-facing messages: en, sl, de.
+# Language for user-facing messages: en, sl.
 # Default is English unless explicitly changed in this script or environment.
 FIDO2LUKS_LANG=${FIDO2LUKS_LANG:-en}
 

--- a/keyscript.sh
+++ b/keyscript.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-# Copyright (C) 2024-2025 Alberto Garcia <berto@igalia.com>
-# SPDX-License-Identifier: GPL-2.0-or-later
-
 cleanup () {
-    rm -f "$ASSERT_PARAMS" "$LUKS_TOKEN" "$LUKS_TOKEN_LIST"
+    rm -f "$ASSERT_PARAMS" "$LUKS_TOKEN" "$LUKS_TOKEN_LIST" \
+          "${FIDO2_OUT:-}" "${FIDO2_ERR:-}" "${FIDO2_ERR_FILTERED:-}" "${FIDO2_PIN:-}"
 }
 
 ASSERT_PARAMS=$(mktemp -t params.XXXXXX)
@@ -12,24 +10,176 @@ LUKS_TOKEN_LIST=$(mktemp -t tokenlist.XXXXXX)
 LUKS_TOKEN=$(mktemp -t token.XXXXXX)
 trap cleanup INT EXIT
 
+# Enable or disable technical/debug messages shown via Plymouth (and in text mode).
+# Default is 0 so normal users see only human-readable recovery messages.
+FIDO2LUKS_DEBUG=${FIDO2LUKS_DEBUG:-1}
+
+# Language for user-facing messages: en, sl, de.
+# Default is English unless explicitly changed in this script or environment.
+FIDO2LUKS_LANG=${FIDO2LUKS_LANG:-en}
+
+# Return success only when the Plymouth client exists and
+# the Plymouth daemon is currently running in the initramfs.
+plymouth_available () {
+    command -v plymouth >/dev/null 2>&1 && plymouth --ping >/dev/null 2>&1
+}
+
+# Translate user-facing messages. Keep technical/debug strings outside this
+# function so they remain useful for troubleshooting and upstream reports.
+msg_text () {
+    _msg_id=$1
+    _arg1=${2:-}
+
+    case "$FIDO2LUKS_LANG:$_msg_id" in
+        sl:waiting_key)
+            printf '%s\n' "Čakam na varnostni USB ključ..." ;;
+        *:waiting_key)
+            printf '%s\n' "Waiting for the security USB key..." ;;
+
+        sl:no_key)
+            printf '%s\n' "Varnostnega USB ključa ni bilo mogoče najti!" ;;
+        *:no_key)
+            printf '%s\n' "No security USB key found!" ;;
+
+        sl:pin_prompt)
+            printf '%s\n' "Vnesite PIN za varnostni USB ključ" ;;
+        *:pin_prompt)
+            printf '%s\n' "Enter PIN for security USB key" ;;
+
+        sl:touch_hint)
+            cat <<EOF
+Potrdite svojo prisotnost.
+Dotaknite se varnostnega USB ključa ZDAJ.
+EOF
+            ;;
+
+        *:touch_hint)
+            cat <<EOF
+Please confirm your presence.
+Touch the security USB key NOW.
+EOF
+            ;;
+
+        sl:touch_countdown)
+            cat <<EOF
+Potrdite svojo prisotnost.
+Dotaknite se varnostnega USB ključa ZDAJ.
+
+Prehod na obnovitveno šifrirno geslo čez ${_arg1}s.
+EOF
+
+            ;;
+        *:touch_countdown)
+            cat <<EOF
+Please confirm your presence.
+Touch the security USB key NOW.
+
+Falling back to recovery encryption passphrase in ${_arg1}s.
+EOF
+            ;;
+
+        sl:touch_timeout)
+            cat <<EOF
+Varnostnega ključa se niste pravočasno dotaknili.
+Znova vstavite ključ in ponovno zaženite računalnik,
+ali vnesite obnovitveno šifrirno geslo.
+EOF
+            ;;
+
+        *:touch_timeout)
+            cat <<EOF
+Security key was not touched in time.
+Reinsert the key and reboot computer to retry,
+or enter recovery encryption passphrase.
+EOF
+            ;;
+
+        sl:console_pin_touch)
+            cat <<EOF
+Vnesite PIN za varnostni USB ključ, pritisnite Enter,
+nato se dotaknite varnostnega USB ključa za potrditev prisotnosti.
+EOF
+            ;;
+
+        *:console_pin_touch)
+            cat <<EOF
+Enter PIN for your security USB key, press Enter,
+then touch the security USB key to confirm your presence.
+EOF
+            ;;
+
+        sl:fido_failed)
+            cat <<EOF
+Odklepanje diska z varnostnim USB ključem ni uspelo.
+Znova vstavite ključ in ponovno zaženite računalnik,
+ali vnesite obnovitveno šifrirno geslo.
+EOF
+            ;;
+
+        *:fido_failed)
+            cat <<EOF
+Unlocking disk with security USB key failed.
+Reinsert the key and reboot computer to retry,
+or enter recovery encryption passphrase.
+EOF
+            ;;
+
+        sl:passphrase_fallback)
+            printf '%s\n' "Odklepanje diska z obnovitvenim šifrirnim geslom" ;;
+        *:passphrase_fallback)
+            printf '%s\n' "Unlocking disk using a recovery encryption passphrase" ;;
+
+        sl:passphrase_prompt)
+            printf '%s\n' "Vnesite obnovitveno šifrirno geslo: " ;;
+        *:passphrase_prompt)
+            printf '%s\n' "Enter recovery encryption passphrase: " ;;
+    esac
+}
+
+# Print a status message to the text console as before, and
+# also mirror it to Plymouth when Plymouth is available.
+plymouth_message () {
+    echo "*** $*" >&2
+    if plymouth_available; then
+        plymouth display-message --text="$*" >/dev/null 2>&1 || true
+    fi
+}
+
+# Print technical/debug messages only when FIDO2LUKS_DEBUG=1.
+# Human-readable recovery messages should use plymouth_message directly.
+debug_message () {
+    if [ "$FIDO2LUKS_DEBUG" = "1" ]; then
+        plymouth_message "$@"
+    fi
+}
+
+# Show an explicit hint for the required physical touch step.
+# This is especially useful with graphical Plymouth themes,
+# because the FIDO2 authenticator itself gives no text prompt.
+plymouth_touch_hint () {
+    if [ "$REQ_UP" = "true" ]; then
+        plymouth_message "$(msg_text touch_hint)"
+    fi
+}
+
 try_fido2_unlock () {
     # Get all tokens from the LUKS header with FIDO2 credentials.
     # Sort the array, placing entries with "fido2-uv-required: true" at the end.
     if ! cryptsetup luksDump --dump-json-metadata "$CRYPTTAB_SOURCE" | \
             jq -e '[.tokens[] | select(."fido2-credential" != null)] | sort_by(."fido2-uv-required")' > "$LUKS_TOKEN_LIST"; then
-        echo "*** Error reading LUKS header in $CRYPTTAB_SOURCE" >&2
+        debug_message "Error reading LUKS header in $CRYPTTAB_SOURCE"
         return 1
     fi
 
     # Count how many tokens we have.
     NTOKENS=$(jq length "$LUKS_TOKEN_LIST")
     if [ -z "$NTOKENS" ] || [ "$NTOKENS" = "0" ]; then
-        echo "*** No FIDO2 credentials found in $CRYPTTAB_SOURCE" >&2
+        debug_message "No FIDO2 credentials found in $CRYPTTAB_SOURCE"
         return 1
     fi
 
     # Check if the FIDO2 authenticator is inserted
-    echo "*** Waiting for a FIDO2 authenticator..." >&2
+    plymouth_message "$(msg_text waiting_key)"
     for _f in $(seq 5); do
         FIDO2_AUTHENTICATOR=$(fido2-token -L)
         sleep 1
@@ -37,11 +187,11 @@ try_fido2_unlock () {
     done
 
     if [ -z "$FIDO2_AUTHENTICATOR" ]; then
-        echo "*** No FIDO2 authenticator found" >&2
+        plymouth_message "$(msg_text no_key)"
         return 1
     fi
 
-    echo "*** Found FIDO2 authenticator $FIDO2_AUTHENTICATOR" >&2
+    debug_message "Found FIDO2 authenticator $FIDO2_AUTHENTICATOR"
     FIDO2_DEV=${FIDO2_AUTHENTICATOR%%:*}
 
     # Look for a credential that is valid for the inserted FIDO2
@@ -81,7 +231,7 @@ try_fido2_unlock () {
     done
 
     if [ ! -f "$LUKS_TOKEN" ] || [ ! -f "$ASSERT_PARAMS" ]; then
-        echo "*** No valid credential found for this FIDO2 authenticator" >&2
+        debug_message "No valid credential found for this FIDO2 authenticator"
         return 1
     fi
 
@@ -90,19 +240,105 @@ try_fido2_unlock () {
     REQ_PIN=$(jq -r '."fido2-clientPin-required"' "$LUKS_TOKEN")
     REQ_UP=$(jq -r '."fido2-up-required"' "$LUKS_TOKEN")
 
-    if [ "$REQ_PIN" = "true" ]; then
-        stty -echo
-    fi
+    if [ "$REQ_PIN" = "true" ] && plymouth_available; then
+        # When Plymouth is active, collect the FIDO2 PIN through
+        # Plymouth's normal password dialog. This gives the user
+        # a proper graphical input field instead of a hidden tty
+        # prompt from fido2-assert.
+        PIN=$(plymouth ask-for-password --prompt="$(msg_text pin_prompt)")
 
-    SECRET=$(fido2-assert -G -h -t up="$REQ_UP" -t pin="$REQ_PIN" $UV_OPT \
-                          -i "$ASSERT_PARAMS" "$FIDO2_DEV" | tail -n 1)
+        # Capture fido2-assert output and errors separately so
+        # Plymouth can show a live touch countdown and useful
+        # error messages before falling back to the passphrase.
+        FIDO2_OUT=$(mktemp -t fido2out.XXXXXX)
+        FIDO2_ERR=$(mktemp -t fido2err.XXXXXX)
+        FIDO2_ERR_FILTERED=$(mktemp -t fido2err-filtered.XXXXXX)
+        FIDO2_PIN=$(mktemp -t fido2pin.XXXXXX)
+        chmod 600 "$FIDO2_PIN" 2>/dev/null || true
+        printf "%s\n" "$PIN" > "$FIDO2_PIN"
 
-    if [ "$REQ_PIN" = "true" ]; then
-        stty echo
+        # Clear the shell variable after writing the one-shot PIN
+        # to the initramfs tmpfs file used as fido2-assert stdin.
+        # This is not perfect memory erasure, but avoids keeping
+        # the PIN around longer than necessary in the shell.
+        PIN=""
+
+        # fido2-assert uses /dev/tty for PIN entry when a tty is
+        # available. Run it in a new session and feed stdin from
+        # the PIN file. Do not use "setsid -w" because busybox
+        # setsid in initramfs may not support it.
+        setsid fido2-assert \
+            -G -h -t up="$REQ_UP" -t pin="$REQ_PIN" $UV_OPT \
+            -i "$ASSERT_PARAMS" "$FIDO2_DEV" \
+            < "$FIDO2_PIN" > "$FIDO2_OUT" 2> "$FIDO2_ERR" &
+        FIDO2_PID=$!
+
+        # While fido2-assert waits for user presence, keep the
+        # Plymouth screen informative. If the key is not touched
+        # in time, fall back to the regular disk passphrase.
+        if [ "$REQ_UP" = "true" ]; then
+            for _seconds in 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1; do
+                if ! kill -0 "$FIDO2_PID" 2>/dev/null; then
+                    break
+                fi
+                plymouth_message "$(msg_text touch_countdown "$_seconds")"
+                sleep 1
+            done
+        fi
+
+        if kill -0 "$FIDO2_PID" 2>/dev/null; then
+            # The touch prompt timed out. Stop fido2-assert so the
+            # boot can proceed to the backup passphrase prompt.
+            kill "$FIDO2_PID" 2>/dev/null || true
+            wait "$FIDO2_PID" 2>/dev/null || true
+            plymouth_message "$(msg_text touch_timeout)"
+            sleep 5
+            SECRET=""
+        else
+            wait "$FIDO2_PID" 2>/dev/null || true
+            SECRET=$(tail -n 1 "$FIDO2_OUT")
+        fi
+
+        # fido2-assert still prints its own "Enter PIN for ..."
+        # prompt even when the PIN is supplied on stdin. Filter
+        # that duplicate prompt, but keep real errors visible.
+        if [ -z "$SECRET" ] && [ -s "$FIDO2_ERR" ]; then
+            grep -v "^Enter PIN for " "$FIDO2_ERR" > "$FIDO2_ERR_FILTERED" || true
+            if [ -s "$FIDO2_ERR_FILTERED" ]; then
+                debug_message "$(tail -n 1 "$FIDO2_ERR_FILTERED")"
+                sleep 3
+            fi
+        fi
+
+        rm -f "$FIDO2_OUT" "$FIDO2_ERR" "$FIDO2_ERR_FILTERED" "$FIDO2_PIN"
+    else
+        if [ "$REQ_PIN" = "true" ]; then
+            # Without Plymouth, keep the original console behavior
+            # but make the expected touch step explicit.
+            plymouth_message "$(msg_text console_pin_touch)"
+            stty -echo
+        elif [ "$REQ_UP" = "true" ]; then
+            # If no PIN is required, the user may still need to touch
+            # the authenticator. Make that visible in Plymouth.
+            plymouth_touch_hint
+        fi
+
+        SECRET=$(fido2-assert -G -h -t up="$REQ_UP" -t pin="$REQ_PIN" $UV_OPT \
+                              -i "$ASSERT_PARAMS" "$FIDO2_DEV" | tail -n 1)
+
+        if [ "$REQ_PIN" = "true" ]; then
+            stty echo
+        fi
     fi
 
     if [ -z "$SECRET" ]; then
-        echo "*** Error obtaining secret from $FIDO2_DEV" >&2
+        # Show one combined recovery message so Plymouth themes
+        # do not immediately overwrite earlier lines.
+        plymouth_message "$(msg_text fido_failed)"
+
+        # Give the user time to read the recovery instruction
+        # before falling back to the regular passphrase prompt.
+        sleep 5
         return 1
     fi
 
@@ -116,5 +352,5 @@ if try_fido2_unlock; then
     exit 0
 fi
 
-echo "*** Unlocking $CRYPTTAB_NAME using a regular passphrase" >&2
-/usr/lib/cryptsetup/askpass "Enter passphrase: "
+plymouth_message "$(msg_text passphrase_fallback)"
+/lib/cryptsetup/askpass "$(msg_text passphrase_prompt)"


### PR DESCRIPTION
I updated a script a little so it supports Plymouth graphical bootsplash, multi languages (currently English (default) and Slovenian) and you can also disable technical/debug messages (and show only messages suitable for non-tecnical users).

Script was tested with Yubikey 5 NFC and Nitrokey 3A Mini on Debian 13.4